### PR TITLE
Fixes issue #1: Move some() to src to avoid user import of options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ echo("Saved in ", filename) # Open the file in your favourite music player.
 echo client.synthesizeToFolder(
   "Nim is the best programming language!",
   os.getCurrentDir(),
-  voice=initVoiceSelectionParams(name=some("en-GB-Wavenet-A")),
+  voice=initVoiceSelectionParams(name="en-GB-Wavenet-A"),
   audioConfig=initAudioConfig(audioEncoding=OGG_OPUS, pitch = -5)
 )
 ```

--- a/src/texttospeech.nim
+++ b/src/texttospeech.nim
@@ -97,12 +97,12 @@ proc toRequestData(
 
 
 proc initVoiceSelectionParams*(
-  languageCode="en-GB", ssmlGender=MALE, name=none[string]()
+  languageCode="en-GB", ssmlGender=MALE, name=""
 ): VoiceSelectionParams =
   VoiceSelectionParams(
     languageCode: languageCode,
     ssmlGender: ssmlGender,
-    name: name
+    name: if name == "": none[string]() else: some(name)
   )
 
 proc initAudioConfig*(
@@ -175,6 +175,6 @@ when isMainModule:
     client.synthesizeToFolder(
       "Have you ever felt the cold, determined, voice of a machine?",
       getCurrentDir(),
-      voice=initVoiceSelectionParams(name=some("en-GB-Wavenet-D")),
+      voice=initVoiceSelectionParams(name="en-GB-Wavenet-D"),
       audioConfig=initAudioConfig(audioEncoding=OGG_OPUS, pitch=20))
   echo filename


### PR DESCRIPTION
Moved `some()` used in `client.synthesizeToFolder` to `initVoiceSelectionParams()` instead of requiring the user to import options. The solution is not using either `export` or `bind` - let me know, if you would like me to change the approach.

Fixes issue #1